### PR TITLE
Change in campaign archival command to match hpc-campaign v0.6

### DIFF
--- a/src/effis/composition/workflow.py
+++ b/src/effis/composition/workflow.py
@@ -458,7 +458,7 @@ class Workflow(UseRunner):
                 '''
 
                 #fullcmd = [self.Campaign.ManagerCommand, "--files"] + bp + [subcmd, storepath]
-                fullcmd = [self.Campaign.ManagerCommand, subcmd, storepath, "--files"] + bp
+                fullcmd = [self.Campaign.ManagerCommand, "manager", storepath, subcmd, "dataset"] + bp
 
                 CompositionLogger.Info("Campaign management: {0}".format(' '.join(fullcmd)))
                 subprocess.call(fullcmd)


### PR DESCRIPTION
Latest release v0.6 of [hpc-campaign](https://github.com/ornladios/hpc-campaign) changes the install scripts and usage of the campaign archival tool. This PR updates how effis invokes the archival utility. Currently supporting BP files only through the `dataset` keyword. 